### PR TITLE
Clean up registration to be 2 steps max

### DIFF
--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -45,7 +45,10 @@ const Profile = ({ handleSignout }: ProfileProps) => {
   };
 
   const clearFormValues = () => {
+    // clear input password
     setInputPassword("");
+    setPassword("");
+    setConfirmPassword("");
   };
 
   const updateProfile = async () => {

--- a/src/components/profileFormSteps/index.tsx
+++ b/src/components/profileFormSteps/index.tsx
@@ -218,22 +218,6 @@ const ProfileForm = ({
           {...register("email")}
         />
       </div>
-      {claveInfo && (
-        <div className="flex flex-col gap-2">
-          <span className="text-gray-12 text-sm font-light">Clave</span>
-          {claveInfo.claveWalletAddress ? (
-            <span className="text-gray-12 text-sm font-light">{`Wallet Address: ${claveInfo.claveWalletAddress}`}</span>
-          ) : (
-            <Button
-              type="button"
-              onClick={() => window.open(claveInfo.claveInviteLink, "_blank")}
-              className="bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-600"
-            >
-              Join Clave
-            </Button>
-          )}
-        </div>
-      )}
       <div className="flex flex-col gap-6">
         <div className="flex flex-col">
           <span className="text-gray-12 text-sm font-light">
@@ -285,6 +269,22 @@ const ProfileForm = ({
           />
         </div>
       </div>
+      {claveInfo && (
+        <div className="flex flex-col gap-2">
+          <span className="text-gray-12 text-sm font-light">Clave</span>
+          {claveInfo.claveWalletAddress ? (
+            <span className="text-gray-12 text-sm font-light">{`Wallet Address: ${claveInfo.claveWalletAddress}`}</span>
+          ) : (
+            <Button
+              type="button"
+              onClick={() => window.open(claveInfo.claveInviteLink, "_blank")}
+              className="bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-600"
+            >
+              Join Clave
+            </Button>
+          )}
+        </div>
+      )}
       <div className="flex flex-col gap-6">
         <div className="flex flex-col gap-3">
           <span className="text-gray-12 text-sm font-light">

--- a/src/components/profileFormSteps/index.tsx
+++ b/src/components/profileFormSteps/index.tsx
@@ -234,7 +234,57 @@ const ProfileForm = ({
           )}
         </div>
       )}
-
+      <div className="flex flex-col gap-6">
+        <div className="flex flex-col">
+          <span className="text-gray-12 text-sm font-light">
+            Shareable socials
+          </span>
+          <span className="text-gray-11 text-xs font-light">
+            {`Taps are one way: you choose which socials to share when you tap someone and they see nothing when they tap you.`}
+          </span>
+        </div>
+        <div className="flex flex-col gap-6">
+          <Input
+            label="Twitter"
+            disabled={isReadOnly}
+            error={errors.twitterUsername?.message}
+            {...register("twitterUsername", {
+              onChange: (e) => {
+                const value = e.target.value;
+                handleUsername("twitterUsername", value);
+              },
+            })}
+          />
+          <Input
+            label="Telegram"
+            disabled={isReadOnly}
+            error={errors.telegramUsername?.message}
+            {...register("telegramUsername", {
+              onChange: (e) => {
+                const value = e.target.value;
+                handleUsername("telegramUsername", value);
+              },
+            })}
+          />
+          <Input
+            label="Farcaster"
+            error={errors.farcasterUsername?.message}
+            disabled={isReadOnly}
+            {...register("farcasterUsername", {
+              onChange: (e) => {
+                const value = e.target.value;
+                handleUsername("farcasterUsername", value);
+              },
+            })}
+          />
+          <Input
+            label="Bio"
+            error={errors.bio?.message}
+            disabled={isReadOnly}
+            {...register("bio")}
+          />
+        </div>
+      </div>
       <div className="flex flex-col gap-6">
         <div className="flex flex-col gap-3">
           <span className="text-gray-12 text-sm font-light">
@@ -270,47 +320,6 @@ const ProfileForm = ({
             }
           />
         </div>
-      </div>
-      <div className="flex flex-col gap-6">
-        <Input
-          label="Twitter (Optional)"
-          disabled={isReadOnly}
-          error={errors.twitterUsername?.message}
-          {...register("twitterUsername", {
-            onChange: (e) => {
-              const value = e.target.value;
-              handleUsername("twitterUsername", value);
-            },
-          })}
-        />
-        <Input
-          label="Telegram (Optional)"
-          disabled={isReadOnly}
-          error={errors.telegramUsername?.message}
-          {...register("telegramUsername", {
-            onChange: (e) => {
-              const value = e.target.value;
-              handleUsername("telegramUsername", value);
-            },
-          })}
-        />
-        <Input
-          label="Farcaster (Optional)"
-          error={errors.farcasterUsername?.message}
-          disabled={isReadOnly}
-          {...register("farcasterUsername", {
-            onChange: (e) => {
-              const value = e.target.value;
-              handleUsername("farcasterUsername", value);
-            },
-          })}
-        />
-        <Input
-          label="Bio (Optional)"
-          error={errors.bio?.message}
-          disabled={isReadOnly}
-          {...register("bio")}
-        />
       </div>
     </FormStepLayout>
   );

--- a/src/components/registerFormSteps/code.tsx
+++ b/src/components/registerFormSteps/code.tsx
@@ -83,7 +83,7 @@ const RegisterStepCode = ({ onBack, onSuccess }: RegisterFormStepProps) => {
 
   return (
     <div className="flex flex-col grow">
-      <AppBackHeader label="Email" onBackClick={() => onBack?.()} />
+      <AppBackHeader label={"Back"} onBackClick={() => onBack?.()} />
       <FormStepLayout
         title={`We've just sent you a six digit code to ${email}`}
         description={eventDate}

--- a/src/components/registerFormSteps/password.tsx
+++ b/src/components/registerFormSteps/password.tsx
@@ -72,7 +72,7 @@ const RegisterPassword = ({ onBack, onSuccess }: RegisterFormStepProps) => {
           This master password is used to encrypt a backup of your interaction
           data on our server. You are responsible for saving this password.
         </span>
-        <Button type="submit">Create Account</Button>
+        <Button type="submit">Create account</Button>
       </FormStepLayout>
     </div>
   );

--- a/src/components/registerFormSteps/quickStart.tsx
+++ b/src/components/registerFormSteps/quickStart.tsx
@@ -141,7 +141,7 @@ const RegisterQuickStart = ({
             name="custody"
             value="server"
             label="Server custody"
-            description="Your socials and contacts can be read by app server, but login just requires verifying an email code."
+            description="Your socials and contacts can be read by app server, but login by just verifying an email code."
             checked={wantsServerCustody}
             onChange={() => {
               setValue("wantsServerCustody", true, {
@@ -154,7 +154,7 @@ const RegisterQuickStart = ({
             name="custody"
             value="self"
             label="Self custody"
-            description="Your socials and contacts are private to you, but you must save a master password for encrypted backups. ZK is used to prove quest completion."
+            description="Your socials and contacts are private to you, but you must save a master password for encrypted backups. ZK is used to verifiably unlock prizes."
             checked={!wantsServerCustody}
             onChange={() => {
               setValue("wantsServerCustody", false, {

--- a/src/components/registerFormSteps/quickStart.tsx
+++ b/src/components/registerFormSteps/quickStart.tsx
@@ -106,7 +106,7 @@ const RegisterQuickStart = ({
     <div className="flex flex-col grow">
       <FormStepLayout
         onSubmit={handleSubmit(handleQuickStartSubmit)}
-        description="Share your socials with a tap and win prizes!"
+        description="Tap people's badges to connect and win prizes!"
         title="Join BUIDLQuest"
         className="pt-4"
         header={<></>}

--- a/src/components/registerFormSteps/quickStart.tsx
+++ b/src/components/registerFormSteps/quickStart.tsx
@@ -1,0 +1,175 @@
+import { RegisterSchema } from "@/lib/schema/schema";
+import { InferType } from "yup";
+import { Button } from "../Button";
+import { AppBackHeader } from "../AppHeader";
+import { FormStepLayout } from "@/layouts/FormStepLayout";
+import { yupResolver } from "@hookform/resolvers/yup";
+import { useForm } from "react-hook-form";
+import { Radio } from "../Radio";
+import { useStateMachine } from "little-state-machine";
+import updateStateFromAction from "@/lib/shared/updateAction";
+import { Input } from "../Input";
+import { toast } from "sonner";
+import { REGISTRATION_GET_CODE_STATE } from "@/pages/api/register/get_code";
+import { useState } from "react";
+
+const RegisterQuickStartSchema = RegisterSchema.pick([
+  "email",
+  "displayName",
+  "wantsServerCustody",
+]);
+type RegisterQuickStartProps = InferType<typeof RegisterQuickStartSchema>;
+
+export interface QuickStartProps {
+  iykRef: string;
+  mockRef?: string;
+  onSuccess?: (wantsServerCustody: boolean) => void;
+  onBack?: (wantsServerCustody: boolean) => void;
+  title?: string;
+}
+
+const RegisterQuickStart = ({
+  iykRef,
+  mockRef,
+  onSuccess,
+}: QuickStartProps) => {
+  const { actions, getState } = useStateMachine({ updateStateFromAction });
+  const [loading, setLoading] = useState(false);
+
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    watch,
+    formState: { errors },
+  } = useForm<RegisterQuickStartProps>({
+    resolver: yupResolver(RegisterQuickStartSchema),
+    defaultValues: {
+      email: getState()?.register?.email,
+      displayName: getState()?.register?.displayName ?? "",
+      wantsServerCustody: getState()?.register?.wantsServerCustody ?? false,
+    },
+  });
+
+  const wantsServerCustody = watch("wantsServerCustody", false);
+
+  const handleQuickStartSubmit = async (data: RegisterQuickStartProps) => {
+    actions.updateStateFromAction({
+      register: {
+        ...getState()?.register,
+        ...data,
+      },
+    });
+
+    if (wantsServerCustody) {
+      setLoading(true);
+      // update state with email
+      actions.updateStateFromAction({
+        register: { ...getState().register, email: data.email },
+      });
+
+      const response = await fetch("/api/register/get_code", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ email: data.email, iykRef, mockRef }),
+      });
+      setLoading(false);
+
+      if (!response.ok) {
+        const { error, state } = await response.json();
+        console.error("Error:", error);
+
+        if (state === REGISTRATION_GET_CODE_STATE.CODE_INVALID) {
+          toast.error("Invalid tap! Please try again.");
+        } else if (state === REGISTRATION_GET_CODE_STATE.EMAIL_INVALID) {
+          toast.error(
+            "Please make sure you register with the same email you used to sign up for ETHDenver."
+          );
+        } else if (state === REGISTRATION_GET_CODE_STATE.EMAIL_REGISTERED) {
+          toast.error("This email is already registered.");
+        } else {
+          toast.error("Error requesting email code. Please try again.");
+        }
+        return;
+      } else {
+        onSuccess?.(true); // proceed to verify code
+        return;
+      }
+    }
+
+    onSuccess?.(false); // proceed to password setup
+  };
+
+  return (
+    <div className="flex flex-col grow">
+      <FormStepLayout
+        onSubmit={handleSubmit(handleQuickStartSubmit)}
+        description="Share your socials with a tap and win prizes!"
+        title="Join BUIDLQuest"
+        className="pt-4"
+        header={<></>}
+      >
+        <Input
+          label="Email"
+          placeholder="Your email"
+          error={errors.email?.message}
+          {...register("email")}
+        />
+        <Input
+          type="text"
+          label="Display name"
+          placeholder="Choose name, can change anytime"
+          error={errors.displayName?.message}
+          {...register("displayName")}
+        />
+        <fieldset className="flex flex-col gap-3">
+          <span className="text-gray-12 text-xs">
+            Custody options, built with ZK tech by{" "}
+            <a
+              href="https://cursive.team"
+              target="_blank"
+              rel="noreferrer noopener"
+            >
+              <u>Cursive</u>
+            </a>
+          </span>
+          <Radio
+            id="selfCustody"
+            name="custody"
+            value="self"
+            label="Self custody"
+            description="ETHDenver interaction data is private to you, encrypted by a master password you must save. ZK proofs used to prove quest completion."
+            checked={!wantsServerCustody}
+            onChange={() => {
+              setValue("wantsServerCustody", false, {
+                shouldValidate: true,
+              });
+            }}
+          />
+          <Radio
+            id="serverCustody"
+            type="radio"
+            name="custody"
+            value="server"
+            label="Server custody"
+            description="ETHDenver interaction data can be read by app server, but login just requires verifying an email code."
+            checked={wantsServerCustody}
+            onChange={() => {
+              setValue("wantsServerCustody", true, {
+                shouldValidate: true,
+              });
+            }}
+          />
+        </fieldset>
+        <Button loading={loading} type="submit">
+          {wantsServerCustody ? "Verify email" : "Choose password"}
+        </Button>
+      </FormStepLayout>
+    </div>
+  );
+};
+
+RegisterQuickStart.displayName = "RegisterQuickStart";
+export { RegisterQuickStart };

--- a/src/components/registerFormSteps/quickStart.tsx
+++ b/src/components/registerFormSteps/quickStart.tsx
@@ -136,28 +136,28 @@ const RegisterQuickStart = ({
             </a>
           </span>
           <Radio
-            id="selfCustody"
-            name="custody"
-            value="self"
-            label="Self custody"
-            description="ETHDenver interaction data is private to you, encrypted by a master password you must save. ZK proofs used to prove quest completion."
-            checked={!wantsServerCustody}
-            onChange={() => {
-              setValue("wantsServerCustody", false, {
-                shouldValidate: true,
-              });
-            }}
-          />
-          <Radio
             id="serverCustody"
             type="radio"
             name="custody"
             value="server"
             label="Server custody"
-            description="ETHDenver interaction data can be read by app server, but login just requires verifying an email code."
+            description="Your socials and contacts can be read by app server, but login just requires verifying an email code."
             checked={wantsServerCustody}
             onChange={() => {
               setValue("wantsServerCustody", true, {
+                shouldValidate: true,
+              });
+            }}
+          />
+          <Radio
+            id="selfCustody"
+            name="custody"
+            value="self"
+            label="Self custody"
+            description="Your socials and contacts are private to you, but you must save a master password for encrypted backups. ZK is used to prove quest completion."
+            checked={!wantsServerCustody}
+            onChange={() => {
+              setValue("wantsServerCustody", false, {
                 shouldValidate: true,
               });
             }}

--- a/src/components/registerFormSteps/quickStart.tsx
+++ b/src/components/registerFormSteps/quickStart.tsx
@@ -51,9 +51,10 @@ const RegisterQuickStart = ({
     },
   });
 
-  const wantsServerCustody = watch("wantsServerCustody", false);
+  const wantsServerCustody = watch("wantsServerCustody");
 
   const handleQuickStartSubmit = async (data: RegisterQuickStartProps) => {
+    // update state with current form data
     actions.updateStateFromAction({
       register: {
         ...getState()?.register,
@@ -63,11 +64,6 @@ const RegisterQuickStart = ({
 
     if (wantsServerCustody) {
       setLoading(true);
-      // update state with email
-      actions.updateStateFromAction({
-        register: { ...getState().register, email: data.email },
-      });
-
       const response = await fetch("/api/register/get_code", {
         method: "POST",
         headers: {
@@ -109,7 +105,7 @@ const RegisterQuickStart = ({
         description="Tap people's badges to share socials and win prizes!"
         title="Join BUIDLQuest"
         className="pt-4"
-        header={<></>}
+        header={null}
       >
         <Input
           label="Email"

--- a/src/components/registerFormSteps/quickStart.tsx
+++ b/src/components/registerFormSteps/quickStart.tsx
@@ -106,21 +106,21 @@ const RegisterQuickStart = ({
     <div className="flex flex-col grow">
       <FormStepLayout
         onSubmit={handleSubmit(handleQuickStartSubmit)}
-        description="Tap people's badges to connect and win prizes!"
+        description="Tap people's badges to share socials and win prizes!"
         title="Join BUIDLQuest"
         className="pt-4"
         header={<></>}
       >
         <Input
           label="Email"
-          placeholder="Your email"
+          placeholder="Login email address"
           error={errors.email?.message}
           {...register("email")}
         />
         <Input
           type="text"
           label="Display name"
-          placeholder="Choose name, can change anytime"
+          placeholder="In-app name, can change anytime"
           error={errors.displayName?.message}
           {...register("displayName")}
         />

--- a/src/pages/api/register/create_account.ts
+++ b/src/pages/api/register/create_account.ts
@@ -20,7 +20,6 @@ const createAccountSchema = object({
   iykRef: string().required(),
   mockRef: string().optional().default(undefined),
   email: string().email().trim().lowercase().required(),
-  code: string().required(),
   displayName: string().trim().required(),
   wantsServerCustody: boolean().required(),
   allowsAnalytics: boolean().required(),
@@ -57,7 +56,6 @@ export default async function handler(
     iykRef,
     mockRef,
     email,
-    code,
     displayName,
     wantsServerCustody,
     allowsAnalytics,
@@ -99,12 +97,6 @@ export default async function handler(
     if (!emailMatchesChipId) {
       return res.status(400).json({ error: "Email does not match iykRef" });
     }
-  }
-
-  // Verify the signin code is valid
-  const verifySigninCodeResult = await verifySigninCode(email, code, true);
-  if (!verifySigninCodeResult.success) {
-    return res.status(400).json({ error: "Invalid email code" });
   }
 
   // Fetch a clave invite code

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -87,7 +87,7 @@ const FeedContent = ({ title, description, icon }: FeedContentProps) => {
         <div className="flex justify-center items-center h-6 w-6 rounded-full bg-[#323232]">
           {icon}
         </div>
-        <Card.Title className="break-all">{title}</Card.Title>
+        <Card.Title>{title}</Card.Title>
       </div>
       <Card.Description>{description}</Card.Description>
     </div>
@@ -97,11 +97,26 @@ const FeedContent = ({ title, description, icon }: FeedContentProps) => {
 const ActivityFeed = ({ type, name, id, date }: ActivityFeedProps) => {
   switch (type) {
     case JUB_SIGNAL_MESSAGE_TYPE.REGISTERED:
+      const profile = getProfile();
+      if (
+        profile?.bio ||
+        profile?.telegramUsername ||
+        profile?.twitterUsername ||
+        profile?.farcasterUsername
+      ) {
+        return (
+          <FeedContent
+            title="Registered and set up profile!"
+            description={date}
+            icon={<CircleCard icon="person" />}
+          />
+        );
+      }
       return (
         <FeedContent
-          title="Registered for BUIDLQuest!"
+          title="Registered! Set up your socials in upper-right menu."
           description={date}
-          icon={<CircleCard icon="person" />}
+          icon={<CircleCard icon="proof" />}
         />
       );
     case JUB_SIGNAL_MESSAGE_TYPE.OUTBOUND_TAP:

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -108,7 +108,7 @@ const ActivityFeed = ({ type, name, id, date }: ActivityFeedProps) => {
           <FeedContent
             title="Registered and set up socials!"
             description={date}
-            icon={<CircleCard icon="person" />}
+            icon={<CircleCard icon="proof" />}
           />
         );
       }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -106,7 +106,7 @@ const ActivityFeed = ({ type, name, id, date }: ActivityFeedProps) => {
       ) {
         return (
           <FeedContent
-            title="Registered and set up profile!"
+            title="Registered and set up socials!"
             description={date}
             icon={<CircleCard icon="person" />}
           />

--- a/src/pages/register.tsx
+++ b/src/pages/register.tsx
@@ -13,7 +13,6 @@ import {
 } from "@/lib/client/localStorage";
 import { encryptBackupString } from "@/lib/shared/backup";
 import { toast } from "sonner";
-import { Spinner } from "@/components/Spinner";
 import { loadMessages } from "@/lib/client/jubSignalClient";
 import { encryptRegisteredMessage } from "@/lib/client/jubSignal/registered";
 import { RegisterStepForm } from "@/components/registerFormSteps";
@@ -32,6 +31,7 @@ enum DisplayState {
   INPUT_EMAIL,
   INPUT_CODE,
   INPUT_SOCIAL,
+  QUICK_START,
   CHOOSE_CUSTODY,
   INPUT_PASSWORD,
   CREATING_ACCOUNT,
@@ -46,7 +46,7 @@ export default function Register() {
   const allowsAnalytics = getState()?.register?.allowsAnalytics ?? false;
 
   const [displayState, setDisplayState] = useState<DisplayState>(
-    DisplayState.INPUT_EMAIL
+    DisplayState.QUICK_START
   );
   const [iykRef, setIykRef] = useState<string>("");
   const [mockRef, setMockRef] = useState<string>();
@@ -60,6 +60,20 @@ export default function Register() {
       setMockRef(router.query.mockRef as string);
     }
   }, [router.query.iykRef, router.query.mockRef]);
+
+  const quickStartHandleAccount = async () => {
+    const { privateKey, publicKey } = await generateEncryptionKeyPair();
+    const { signingKey, verifyingKey } = generateSignatureKeyPair();
+    setSignatureKeyArt(verifyingKey);
+
+    const { displayName, password } = getState().register;
+
+    let passwordSalt, passwordHash;
+    if (!wantsServerCustody) {
+      passwordSalt = generateSalt();
+      passwordHash = await hashPassword(password, passwordSalt);
+    }
+  };
 
   const handleCreateAccount = async () => {
     setDisplayState(DisplayState.CREATING_ACCOUNT);

--- a/src/pages/register.tsx
+++ b/src/pages/register.tsx
@@ -27,6 +27,7 @@ import { ArtworkSnapshot } from "@/components/artwork/ArtworkSnapshot";
 import { InputDescription } from "@/components/input/InputWrapper";
 import { Icons } from "@/components/Icons";
 import { RegisterQuickStart } from "@/components/registerFormSteps/quickStart";
+import { Button } from "@/components/Button";
 
 enum DisplayState {
   INPUT_EMAIL,
@@ -52,6 +53,7 @@ export default function Register() {
   const [iykRef, setIykRef] = useState<string>("");
   const [mockRef, setMockRef] = useState<string>();
   const [signatureKeyArt, setSignatureKeyArt] = useState<string>();
+  const [accountCreated, setAccountCreated] = useState(false);
 
   useEffect(() => {
     if (router.query.iykRef) {
@@ -207,8 +209,7 @@ export default function Register() {
       return;
     }
 
-    toast.success("Account created and backed up!");
-    router.push("/");
+    setAccountCreated(true);
   };
 
   return (
@@ -261,7 +262,7 @@ export default function Register() {
                   isVisible
                 />
               </div>
-              <div className={`flex flex-col gap-2 mt-4 px-10`}>
+              <div className={`flex flex-col gap-2 mt-8 px-10`}>
                 <InputDescription>
                   This is your unique stamp that you will share with other
                   ETHDenver attendees upon tap.
@@ -271,21 +272,32 @@ export default function Register() {
                   verifiably prove they met you.
                 </InputDescription>
                 <InputDescription>
-                  Your stamp collection can be minted as an NFT at the end of
-                  the event!
+                  Your final stamp collection can be minted as an NFT! Browse
+                  its history from your profile.
                 </InputDescription>
               </div>
             </>
           )}
           <div className="mt-8">
-            <div className="flex flex-col gap-4 text-center">
-              <div className="mx-auto">
-                <Icons.loading size={28} className="animate-spin" />
+            {accountCreated ? (
+              <Button
+                onClick={() => {
+                  toast.success("Account created and backed up!");
+                  router.push("/");
+                }}
+              >
+                Enter BUIDLQuest!
+              </Button>
+            ) : (
+              <div className="flex flex-col gap-4 text-center">
+                <div className="mx-auto">
+                  <Icons.loading size={28} className="animate-spin" />
+                </div>
+                <span className="text-sm text-gray-11 leading-5 font-light">
+                  Your account is being created.
+                </span>
               </div>
-              <span className="text-sm text-gray-11 leading-5 font-light">
-                Your account is being created.
-              </span>
-            </div>
+            )}
           </div>
         </div>
       )}

--- a/src/pages/register.tsx
+++ b/src/pages/register.tsx
@@ -69,7 +69,6 @@ export default function Register() {
 
   const artworkSize = pageWidth - 64;
 
-  // keeping old code here for easy port
   const handleCreateAccount = async () => {
     setDisplayState(DisplayState.CREATING_ACCOUNT);
 
@@ -304,6 +303,7 @@ export default function Register() {
     </>
   );
 
+  // keeping old code here for easy port
   return (
     <>
       {displayState === DisplayState.INPUT_EMAIL && (

--- a/src/pages/users/[id]/share.tsx
+++ b/src/pages/users/[id]/share.tsx
@@ -205,7 +205,11 @@ const SharePage = () => {
             isVisible
           />
         </div>
-
+        {!hasSocialLinks && !profile.bio && (
+          <Description>
+            {`No socials set up. Add your socials in the upper-right menu from the home page to selectively share upon tap!`}
+          </Description>
+        )}
         {(hasSocialLinks || profile.bio) && (
           <div className="flex flex-col gap-4">
             <div className="flex flex-col gap-3">
@@ -274,7 +278,7 @@ const SharePage = () => {
           }}
         />
         <Button loading={loading} type="submit">
-          Share
+          Submit
         </Button>
       </FormStepLayout>
     </div>


### PR DESCRIPTION
When talking to a handful of friends about the app and asking them to register, basically all of them didn't finish. I think this is because:
- There are too many steps (4 for server custody, 5 for self custody)
- There isn't any explanation on the registration screen about what the app does
- You are prompted to enter in a LOT of social info
  -  It is optional, but it still is overwhelming and might feel like the app is collecting all of this data

I did a refactor to make registration to 2 screens in both cases:
- Not requiring email code if you're doing self-custody (just password, don't need to verify email just need for login)
- Combining displayName/email/custody into one succinct screen
- Prompting user to set up socials after registering by changing the registration message + having an explanatory note on the share screen if they have no socials

I think it's extremely crucial for growth that people can set up their accounts easily. This is because
- You can start tapping other people and completing quests and getting hyped
- Other people can start tapping you
- You can see the NFT art concept and get hyped about that
- You can poke around the quests and learn about the sick ass store